### PR TITLE
HOTT-4959: Schedule Database Dumps Earlier

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -66,4 +66,4 @@ functions:
         - names:
             - "trade-tariff-be-rd-${sls:stage}"
     events:
-      - schedule: cron(0 12 * * ? *) # Run every day at 1200 UTC
+      - schedule: cron(0 9 * * ? *) # Run every day at 0900 UTC


### PR DESCRIPTION
### Jira Link

[HOTT-4959](https://transformuk.atlassian.net/browse/HOTT-4951)

### What?

I have added/removed/altered:

- Changed trigger to be at 0900 UTC

### Why?

I am doing this because:

- These currently occur at midday but in the event of a sync issue its useful to get a dump of the data as soon as possible - whilst giving adequate time for a delayed sync to still occur
