### PR TITLE
fix: add bash to Dockerfile to support backup.sh execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG DISTRO_VERSION="3.16"
 
 FROM python:${RUNTIME_VERSION}-alpine${DISTRO_VERSION} AS python-alpine
 RUN apk add --no-cache \
+    bash               \
     curl               \
     libcurl            \
     libstdc++          \
@@ -11,6 +12,7 @@ RUN apk add --no-cache \
 
 FROM python-alpine AS build-image
 RUN apk add --no-cache \
+    bash               \
     autoconf           \
     automake           \
     build-base         \

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,12 +5,6 @@ plugins:
   - serverless-vpc-discovery
   - serverless-plugin-utils
 
-custom:
-  db-secret:
-    development: "tradetariffpostgresdevelopment-connection-string"
-    staging: "aurora-postgres-rw-connection-string"
-    production: "aurora-postgres-rw-connection-string"
-
 provider:
   name: aws
   region: eu-west-2
@@ -47,7 +41,6 @@ provider:
         - secretsmanager:DescribeSecret
         - secretsmanager:ListSecretVersionIds
       Resource:
-        - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:tradetariffpostgres${sls:stage}-connection-string-*"
         - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:aurora-postgres-rw-connection-string-*"
 
     - Effect: "Allow"
@@ -75,7 +68,7 @@ functions:
   backup:
     image: database-backups
     environment:
-      DATABASE_SECRET: ${self:custom.db-secret.${self:provider.stage}}
+      DATABASE_SECRET: aurora-postgres-rw-connection-string
     vpcDiscovery:
       vpcName: "trade-tariff-${sls:stage}-vpc"
       subnets:


### PR DESCRIPTION
### Jira Link

### What?

I have added/removed/altered:

- [x] Added `bash` to all relevant `apk add` commands in the Dockerfile.
- [x] Set DATABASE_SECRET to aurora-postgres-rw-connection-string for all environments
- [x] Removed the custom.db-secret stage-specific logic
- [x] Updated IAM policy to only allow access to the unified secret

### Why?

I am doing this because:

**Production**
- The Alpine-based Docker image used in the app did not include `bash` by default. Since `backup.sh` uses `#!/usr/bin/env bash`, this led to a runtime error: env: can't execute 'bash': No such file or directory
- As a result, daily database backups were not being performed, even though the Lambda was scheduled to run.

**Development**
- An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret.



### AC
