### PR TITLE
Fix prod deploy triggers

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,10 +1,13 @@
 name: Deploy to Production
 
 on:
-  push:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Deploy to Staging"]
+    types:
+      - completed
     branches:
       - main
-  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -17,6 +20,7 @@ env:
 
 jobs:
   build-and-push:
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,10 +1,10 @@
 name: Deploy to Staging
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Jira Link
[HMRC-1458](https://transformuk.atlassian.net/browse/HMRC-1458)

### What?

I have added/removed/altered:

- [x] switched the prod workflow trigger from push to workflow_run

### Why?

I am doing this because:

- Ensure production is deployed after a successful automated staging deployment from the main branch

### AC
