### PR TITLE
HMRC-1604: Updates replication secret reference and permissions

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -65,6 +65,6 @@ jobs:
 
       - run: yarn run serverless deploy --verbose
         env:
-          DATABASE_SECRET: production-postgres-database-url
+          DATABASE_SECRET: production-postgres-17-5-database-url
           DOCKER_TAG: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
           STAGE: production

--- a/serverless.yml
+++ b/serverless.yml
@@ -43,6 +43,7 @@ provider:
       Resource:
         - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:aurora-postgres-rw-connection-string-*"
         - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:*-postgres-database-url-*"
+        - "arn:aws:secretsmanager:eu-west-2:${aws:accountId}:secret:*-postgres-*-database-url-*"
 
     - Effect: "Allow"
       Action:


### PR DESCRIPTION
### Jira Link

[HMRC-1604](https://transformuk.atlassian.net/browse/HMRC-1604)

### What?

I have added/removed/altered:

- [x] Added permissions to access new secret
- [x] Updated secret we use to replicate the database

### Why?

I am doing this because:

- We're migrating to postgres 17.5
