### PR TITLE
HMRC-1715: Add log groups retention

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,17 @@
 ---
 repos:
   - repo: https://github.com/hadolint/hadolint
-    rev: v2.13.1-beta
+    rev: v2.14.0
     hooks:
       - id: hadolint-docker
 
   - repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.10.0
+    rev: v0.11.0
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -19,6 +19,6 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.7
+    rev: v1.7.8
     hooks:
       - id: actionlint-docker

--- a/serverless.yml
+++ b/serverless.yml
@@ -83,3 +83,17 @@ functions:
             - "trade-tariff-alb-security-group-${sls:stage}"
     events:
       - schedule: cron(0 9 * * ? *) # Run every day at 0900 UTC (BWT)
+
+custom:
+  logRetentionInDays:
+    development: 7
+    staging: 14
+    production: 30
+
+resources:
+  Resources:
+    BackupLogGroup:
+      Type: AWS::Logs::LogGroup
+      Properties:
+        LogGroupName: /aws/lambda/${self:service}-${sls:stage}-backup
+        RetentionInDays: ${self:custom.logRetentionInDays.${sls:stage}, 14}


### PR DESCRIPTION
### Jira Link
[HMRC-1715](https://transformuk.atlassian.net/browse/HMRC-1715)

### What?

I have added/removed/altered:

- [x] Added a custom CloudWatch log group resource in serverless.yml to explicitly manage log retention.

### Why?

I am doing this because:

- This change allows us to set retention periods (dev, staging, prod) safely via Serverless/CloudFormation.

### AC
