### PR TITLE
HMRC-2071: Add workflow to destroy serverless resources

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -65,8 +65,8 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: yarn run serverless deploy --verbose
+      - run: yarn run serverless remove --verbose
         env:
           DATABASE_SECRET: aurora-postgres-rw-connection-string
-          DOCKER_TAG: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          DOCKER_TAG: latest
           STAGE: development

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -63,8 +63,8 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: yarn run serverless deploy --verbose
+      - run: yarn run serverless remove --verbose
         env:
-          DATABASE_SECRET: production-postgres-database-url
-          DOCKER_TAG: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
-          STAGE: production
+          DATABASE_SECRET: aurora-postgres-rw-connection-string
+          DOCKER_TAG: latest
+          STAGE: staging

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -56,8 +56,8 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: yarn run serverless deploy --verbose
+      - run: yarn run serverless remove --verbose
         env:
           DATABASE_SECRET: aurora-postgres-rw-connection-string
-          DOCKER_TAG: ${{ steps.docker-tag.outputs.DOCKER_TAG }}
+          DOCKER_TAG: latest
           STAGE: staging


### PR DESCRIPTION
### Jira link

[HMRC-2071](https://transformuk.atlassian.net/browse/HMRC-2071)

### What?

- [x] Add `destroy.yml` workflow that runs `serverless remove` for all three environments

### Why?

Database backups have been migrated to the backend ECS `backend-job` task. This workflow tears down the Lambda function, EventBridge rule, IAM role, and CloudWatch log group in each environment.

### How to use

1. Merge this PR
2. Go to Actions > "Destroy Serverless Resources" > Run workflow
3. Once complete, the repo can be archived via [trade-tariff-team#116](https://github.com/trade-tariff/trade-tariff-team/pull/116)